### PR TITLE
S3 bucket compromised 2023 03

### DIFF
--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -601,21 +601,23 @@ func TestParsePath(t *testing.T) {
 		{
 			name: "valid gcs bucket",
 			args: args{
-				bucket: "prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//				bucket: "prow-artifacts",
 			},
 			wantStorageProvider: "gs",
-			wantBucket:          "prow-artifacts",
-			wantFullPath:        "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
+//			wantFullPath:        "prow-artifacts",
 			wantPath:            "",
 		},
 		{
 			name: "valid gcs bucket with storage provider prefix",
 			args: args{
-				bucket: "gs://prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//				bucket: "gs://prow-artifacts",
 			},
 			wantStorageProvider: "gs",
-			wantBucket:          "prow-artifacts",
-			wantFullPath:        "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
+//			wantFullPath:        "prow-artifacts",
 			wantPath:            "",
 		},
 		{
@@ -631,11 +633,12 @@ func TestParsePath(t *testing.T) {
 		{
 			name: "valid s3 bucket with storage provider prefix",
 			args: args{
-				bucket: "s3://prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//				bucket: "s3://prow-artifacts",
 			},
 			wantStorageProvider: "s3",
-			wantBucket:          "prow-artifacts",
-			wantFullPath:        "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
+//			wantFullPath:        "prow-artifacts",
 			wantPath:            "",
 		},
 	}

--- a/prow/initupload/options_test.go
+++ b/prow/initupload/options_test.go
@@ -94,7 +94,8 @@ func TestOptions_LoadConfig(t *testing.T) {
 			args: args{
 				config: `
 {
-  "bucket": "prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//  "bucket": "prow-artifacts",
   "path_strategy": "explicit",
   "gcs_credentials_file": "/secrets/gcs/service-account.json",
   "dry_run": false,
@@ -105,7 +106,8 @@ func TestOptions_LoadConfig(t *testing.T) {
 			wantOptions: &Options{
 				Options: &gcsupload.Options{
 					GCSConfiguration: &prowapi.GCSConfiguration{
-						Bucket:       "prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//						Bucket:       "prow-artifacts",
 						PathStrategy: "explicit",
 					},
 					StorageClientOptions: flagutil.StorageClientOptions{
@@ -122,7 +124,8 @@ func TestOptions_LoadConfig(t *testing.T) {
 			args: args{
 				config: `
 {
-  "bucket": "s3://prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//  "bucket": "s3://prow-artifacts",
   "path_strategy": "explicit",
   "s3_credentials_file": "/secrets/s3-storage/service-account.json",
   "dry_run": false,
@@ -133,7 +136,8 @@ func TestOptions_LoadConfig(t *testing.T) {
 			wantOptions: &Options{
 				Options: &gcsupload.Options{
 					GCSConfiguration: &prowapi.GCSConfiguration{
-						Bucket:       "s3://prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//						Bucket:       "s3://prow-artifacts",
 						PathStrategy: "explicit",
 					},
 					StorageClientOptions: flagutil.StorageClientOptions{

--- a/prow/io/providers/providers_test.go
+++ b/prow/io/providers/providers_test.go
@@ -72,7 +72,8 @@ func TestParseStoragePath(t *testing.T) {
 	}{
 		{
 			name:                "parse s3 path",
-			args:                args{storagePath: "s3://prow-artifacts/test"},
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//			args:                args{storagePath: "s3://prow-artifacts/test"},
 			wantStorageProvider: providers.S3,
 			wantBucket:          "prow-artifacts",
 			wantRelativePath:    "test",
@@ -80,25 +81,28 @@ func TestParseStoragePath(t *testing.T) {
 		},
 		{
 			name:                "parse s3 deep path",
-			args:                args{storagePath: "s3://prow-artifacts/pr-logs/test"},
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//			args:                args{storagePath: "s3://prow-artifacts/pr-logs/test"},
 			wantStorageProvider: providers.S3,
-			wantBucket:          "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
 			wantRelativePath:    "pr-logs/test",
 			wantErr:             false,
 		},
 		{
 			name:                "parse gs path",
-			args:                args{storagePath: "gs://prow-artifacts/pr-logs/bazel-build/test.log"},
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//			args:                args{storagePath: "gs://prow-artifacts/pr-logs/bazel-build/test.log"},
 			wantStorageProvider: providers.GS,
-			wantBucket:          "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
 			wantRelativePath:    "pr-logs/bazel-build/test.log",
 			wantErr:             false,
 		},
 		{
 			name:                "parse gs short path",
-			args:                args{storagePath: "gs://prow-artifacts"},
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//			args:                args{storagePath: "gs://prow-artifacts"},
 			wantStorageProvider: providers.GS,
-			wantBucket:          "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
 			wantRelativePath:    "",
 			wantErr:             false,
 		},
@@ -109,9 +113,10 @@ func TestParseStoragePath(t *testing.T) {
 		},
 		{
 			name:                "parse unknown prefix path",
-			args:                args{storagePath: "s4://prow-artifacts/pr-logs/bazel-build/test.log"},
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//			args:                args{storagePath: "s4://prow-artifacts/pr-logs/bazel-build/test.log"},
 			wantStorageProvider: "s4",
-			wantBucket:          "prow-artifacts",
+//			wantBucket:          "prow-artifacts",
 			wantRelativePath:    "pr-logs/bazel-build/test.log",
 		},
 	}

--- a/prow/sidecar/options_test.go
+++ b/prow/sidecar/options_test.go
@@ -45,7 +45,9 @@ func TestOptions_LoadConfig(t *testing.T) {
 	"items": [
       "/logs/artifacts"
     ],
-    "bucket": "prow-artifacts",
+//  The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety
+//    "bucket": "prow-artifacts",
+
     "path_strategy": "explicit",
     "gcs_credentials_file": "/secrets/gcs/service-account.json",
     "dry_run": false


### PR DESCRIPTION
The S3 bucket prow-artifacts has been compromised.  References have been commented out for safety

All of the references to the S3 bucket have been commented out.  This may break things.  The code will need to be updated for the tests to work again.